### PR TITLE
feat: add RFC3597 support for DNS rewrite

### DIFF
--- a/config.go
+++ b/config.go
@@ -251,12 +251,24 @@ func GenerateExampleConfig() string {
 
 	config.Rewrite = []RewriteRule{
 		{
-			Match:   "blocked.example.com",
-			Replace: "127.0.0.1",
+			Name: "blocked.example.com",
+			Records: []DNSRecordConfig{
+				{
+					Type:    "A",
+					Content: "127.0.0.1",
+					TTL:     300,
+				},
+			},
 		},
 		{
-			Match:   "ipv6.blocked.example.com",
-			Replace: "::1",
+			Name: "ipv6.blocked.example.com",
+			Records: []DNSRecordConfig{
+				{
+					Type:    "AAAA",
+					Content: "::1",
+					TTL:     300,
+				},
+			},
 		},
 	}
 
@@ -300,8 +312,14 @@ func (cm *ConfigManager) addDDRRecords(config *ServerConfig) {
 	// 添加IPv4重写规则
 	if config.Server.DDR.IPv4 != "" {
 		ipv4Rule := RewriteRule{
-			Match:   domain,
-			Replace: config.Server.DDR.IPv4,
+			Name: domain,
+			Records: []DNSRecordConfig{
+				{
+					Type:    "A",
+					Content: config.Server.DDR.IPv4,
+					TTL:     300,
+				},
+			},
 		}
 		config.Rewrite = append(config.Rewrite, ipv4Rule)
 		writeLog(LogDebug, "📝 添加DDR IPv4重写规则: %s -> %s", domain, config.Server.DDR.IPv4)
@@ -310,8 +328,14 @@ func (cm *ConfigManager) addDDRRecords(config *ServerConfig) {
 	// 添加IPv6重写规则
 	if config.Server.DDR.IPv6 != "" {
 		ipv6Rule := RewriteRule{
-			Match:   domain,
-			Replace: config.Server.DDR.IPv6,
+			Name: domain,
+			Records: []DNSRecordConfig{
+				{
+					Type:    "AAAA",
+					Content: config.Server.DDR.IPv6,
+					TTL:     300,
+				},
+			},
 		}
 		config.Rewrite = append(config.Rewrite, ipv6Rule)
 		writeLog(LogDebug, "📝 添加DDR IPv6重写规则: %s -> %s", domain, config.Server.DDR.IPv6)

--- a/types.go
+++ b/types.go
@@ -170,8 +170,20 @@ type RefreshRequest struct {
 
 // RewriteRule DNS重写规则
 type RewriteRule struct {
-	Match   string `json:"match"`   // 需要匹配的域名
-	Replace string `json:"replace"` // 替换的域名或IP地址
+	Name string `json:"name"` // 需要匹配的域名
+
+	// 新增字段支持响应码重写（数字形式）
+	ResponseCode *int `json:"response_code,omitempty"` // 响应码: 0=NOERROR, 2=SERVFAIL, 3=NXDOMAIN, 5=REFUSED 等
+
+	// 新增字段支持所有类型DNS记录重写，使用更简单的格式
+	Records []DNSRecordConfig `json:"records,omitempty"` // DNS记录列表
+}
+
+// DNSRecordConfig DNS记录配置，更接近标准DNS区域文件格式
+type DNSRecordConfig struct {
+	Type    string `json:"type"`          // 记录类型字符串: A, AAAA, CNAME, TXT, MX, NS, PTR, SRV等
+	TTL     uint32 `json:"ttl,omitempty"` // TTL值，默认使用300
+	Content string `json:"content"`       // 记录内容（RDATA）
 }
 
 // ServerConfig 服务器配置


### PR DESCRIPTION
## Sourcery 总结

通过允许规则覆盖响应代码并指定任何类型的自定义 DNS 记录（支持 RFC3597 回退），增加了高级 DNS 重写功能，重构了重写 API 以返回详细结果，并相应地更新了配置 schema。

新功能：
- 允许重写规则指定自定义 DNS 响应代码
- 允许重写规则通过 DNSRecordConfig 定义任意 DNS 记录
- 对于未知或不支持的 DNS 类型，回退到 RFC3597 原始记录格式

改进：
- 将 DNSRewriter.Rewrite 替换为 RewriteWithDetails，后者返回 DNSRewriteResult（包含域、响应代码和记录）
- 更新 ProcessDNSQuery 以处理详细的重写结果，包括响应代码、自定义记录和带调试跟踪的域名重写
- 引入 buildDNSRecord 辅助函数，使用 dns.NewRR 或 RFC3597 回退来构建带有 TTL 和内容的 DNS 记录
- 简化规则验证，仅针对 RFC 限制强制执行名称长度
- 更新 RewriteRule 结构，将 Match/Replace 重命名为 Name，并添加 ResponseCode 和 Records 字段，同时修订示例配置和 DDR 规则生成

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add advanced DNS rewrite capabilities by allowing rules to override response codes and specify custom DNS records of any type (with RFC3597 fallback), refactor the rewrite API to return detailed results, and update the configuration schema accordingly

New Features:
- Allow rewrite rules to specify custom DNS response codes
- Allow rewrite rules to define arbitrary DNS records via DNSRecordConfig
- Fallback to RFC3597 raw record format for unknown or unsupported DNS types

Enhancements:
- Replace DNSRewriter.Rewrite with RewriteWithDetails returning DNSRewriteResult (domain, response code, and records)
- Update ProcessDNSQuery to handle detailed rewrite results including response codes, custom records, and domain name rewrites with debug tracking
- Introduce buildDNSRecord helper to construct DNS records with TTL and content, using dns.NewRR or RFC3597 fallback
- Simplify rule validation to only enforce Name length against RFC limits
- Update RewriteRule struct by renaming Match/Replace to Name and adding ResponseCode and Records fields, and revise example config and DDR rule generation

</details>