### PR TITLE
Revert "chore: migrate DDR record to new rewrite func"

### DIFF
--- a/config.go
+++ b/config.go
@@ -309,30 +309,15 @@ func (cm *ConfigManager) shouldEnableDDR(config *ServerConfig) bool {
 func (cm *ConfigManager) addDDRRecords(config *ServerConfig) {
 	domain := strings.TrimSuffix(config.Server.DDR.Domain, ".")
 
-	// 创建通用的SVCB记录配置
-	svcbRecords := []DNSRecordConfig{
-		{
-			Type:    "SVCB",
-			Content: "1 . alpn=doq,dot port=" + config.Server.TLS.Port,
-		},
-		{
-			Type:    "SVCB",
-			Content: "2 . alpn=h3,h2 port=" + config.Server.TLS.HTTPS.Port,
-		},
-	}
-
-	// 添加IPv4和IPv6提示
+	// 添加IPv4重写规则
 	if config.Server.DDR.IPv4 != "" {
-		svcbRecords[0].Content += " ipv4hint=" + config.Server.DDR.IPv4
-		svcbRecords[1].Content += " ipv4hint=" + config.Server.DDR.IPv4
-
-		// 添加IPv4重写规则
 		ipv4Rule := RewriteRule{
 			Name: domain,
 			Records: []DNSRecordConfig{
 				{
 					Type:    "A",
 					Content: config.Server.DDR.IPv4,
+					TTL:     300,
 				},
 			},
 		}
@@ -340,45 +325,19 @@ func (cm *ConfigManager) addDDRRecords(config *ServerConfig) {
 		writeLog(LogDebug, "📝 添加DDR IPv4重写规则: %s -> %s", domain, config.Server.DDR.IPv4)
 	}
 
+	// 添加IPv6重写规则
 	if config.Server.DDR.IPv6 != "" {
-		svcbRecords[0].Content += " ipv6hint=" + config.Server.DDR.IPv6
-		svcbRecords[1].Content += " ipv6hint=" + config.Server.DDR.IPv6
-
-		// 添加IPv6重写规则
 		ipv6Rule := RewriteRule{
 			Name: domain,
 			Records: []DNSRecordConfig{
 				{
 					Type:    "AAAA",
 					Content: config.Server.DDR.IPv6,
+					TTL:     300,
 				},
 			},
 		}
 		config.Rewrite = append(config.Rewrite, ipv6Rule)
 		writeLog(LogDebug, "📝 添加DDR IPv6重写规则: %s -> %s", domain, config.Server.DDR.IPv6)
-	}
-
-	// 添加DDR SVCB记录规则
-	if config.Server.DDR.IPv4 != "" || config.Server.DDR.IPv6 != "" {
-		// 统一的DDR SVCB记录规则名称列表
-		ddrRuleNames := []string{
-			"_dns.resolver.arpa",
-			"_dns." + domain,
-		}
-
-		// 如果服务器运行在非标准端口上，添加 _port._dns.domain 记录
-		if config.Server.Port != "" && config.Server.Port != DefaultDNSPort {
-			ddrRuleNames = append(ddrRuleNames, "_"+config.Server.Port+"._dns."+domain)
-		}
-
-		// 为每个规则名称添加相同的SVCB记录
-		for _, ruleName := range ddrRuleNames {
-			ddrRule := RewriteRule{
-				Name:    ruleName,
-				Records: svcbRecords,
-			}
-			config.Rewrite = append(config.Rewrite, ddrRule)
-			writeLog(LogDebug, "📝 添加DDR SVCB重写规则: %s", ruleName)
-		}
 	}
 }


### PR DESCRIPTION
Reverts hezhijie0327/ZJDNS#136

## Sourcery 总结

撤销之前的 DDR 迁移，通过重新引入 DDRRecordGenerator 并将 DDR 查询检测和响应逻辑直接集成到 DNS 服务器中，来恢复内联 DDR 记录处理，同时移除基于重写的 DDR 配置。

增强功能：
- 重新引入 DDRRecordGenerator，其包含创建 SVCB 记录和生成 DDR 响应的方法
- 添加 IsDDRQuery 和 parseDDRQueryPort 函数以进行 DDR 查询检测
- 在 ProcessDNSQuery 中集成 DDR 查询处理，以返回动态的 SVCB、A 和 AAAA 记录

清理工作：
- 撤销 ConfigManager 中 DDR 记录配置的迁移，并移除基于重写的 SVCB 规则

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revert the previous DDR migration and restore inline DDR record handling by reintroducing DDRRecordGenerator and integrating DDR query detection and response logic directly into the DNS server, while removing the rewrite-based DDR configuration.

Enhancements:
- Reintroduce DDRRecordGenerator with methods to create SVCB records and generate DDR responses
- Add IsDDRQuery and parseDDRQueryPort functions for DDR query detection
- Integrate DDR query handling in ProcessDNSQuery to return dynamic SVCB, A, and AAAA records

Chores:
- Revert migration of DDR record configuration in ConfigManager and remove rewrite-based SVCB rules

</details>