### PR TITLE
fix: Ensure EDNS ECS/padding for rewrite and direct IP

### DIFF
--- a/main.go
+++ b/main.go
@@ -3389,7 +3389,6 @@ func (s *DNSServer) ProcessDNSQuery(req *dns.Msg, clientIP net.IP, isSecureConne
 		}
 	}
 
-	// Direct IP address response - check after variables are declared
 	clientRequestedDNSSEC := false
 	clientHasEDNS := false
 	var ecsOpt *ECSOption


### PR DESCRIPTION
## Sourcery 总结

通过提取一个辅助函数并相应地移动直接 IP 响应逻辑，确保在 EDNS 解析之后添加 EDNS 客户端子网和填充。

Bug 修复:
- 通过推迟 EDNS 选项的添加，确保 ECS 和填充正确应用于重写和直接 IP 地址响应。

改进:
- 提取 AddEDNStoRewriteResponse 以集中重写流程的 EDNS 选项添加。
- 推迟 EDNS (ECS 和填充) 的添加，直到客户端 EDNS 解析之后，适用于重写和直接 IP 响应。
- 重新定位直接 IP 地址响应逻辑，以允许 EDNS 选项的插入。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

提取 AddEDNStoRewriteResponse 辅助函数，并将 ECS 和 padding 的添加延迟到重写处理之后，以确保 EDNS 选项正确应用于所有重写和直接 IP 响应。

错误修复：
- 确保 ECS 和 padding 选项正确应用于重写和直接 IP 响应，方法是将其添加延迟到重写处理之后。

改进：
- 提取 AddEDNStoRewriteResponse 辅助函数，以集中 EDNS 选项的插入逻辑。
- 重新定位直接 IP 响应逻辑，以便在返回响应之前插入 EDNS 选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract AddEDNStoRewriteResponse helper and defer addition of ECS and padding until after rewrite processing to ensure EDNS options are correctly applied to all rewritten and direct IP responses.

Bug Fixes:
- Ensure ECS and padding options are correctly applied to rewrite and direct IP responses by deferring their addition until after rewrite processing.

Enhancements:
- Extract AddEDNStoRewriteResponse helper to centralize EDNS option insertion logic.
- Relocate direct IP response logic to allow insertion of EDNS options before returning the response.

</details>

</details>