### PR TITLE
chore: show build time in version

### DIFF
--- a/main.go
+++ b/main.go
@@ -5815,9 +5815,6 @@ func main() {
 	if showVersion {
 		fmt.Printf("ZJDNS Server\n")
 		fmt.Printf("Version: %s\n", GetVersion())
-		if BuildTime != "" {
-			fmt.Printf("Built: %s\n", BuildTime)
-		}
 		return
 	}
 


### PR DESCRIPTION
## Sourcery 总结

在应用程序版本中包含构建时间戳并更新默认开发值

增强功能：
- 在 GetVersion 返回的版本字符串中包含构建时间戳
- 将开发版本的默认 CommitHash 更新为 "dirty"，BuildTime 更新为 "dev"

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Include build timestamp in the application version and update default development values

Enhancements:
- Include build timestamp in the version string returned by GetVersion
- Update default CommitHash to "dirty" and BuildTime to "dev" for development builds

</details>